### PR TITLE
Codip 622 add network option

### DIFF
--- a/pesto-cli/pesto/cli/app.py
+++ b/pesto-cli/pesto/cli/app.py
@@ -48,8 +48,8 @@ def parse_args() -> argparse.Namespace:
     parser_test.add_argument('-p', '--profile', nargs='+', help='Select specific files to update',
                              default=None)
     parser_test.add_argument('--nvidia',  action='store_true', default=False, help='Run docker with nvidia-runtime')
-    parser_test.add_argument('-n', '--network', help='Define a specific network for docker construction',
-                              default="host")
+    parser_test.add_argument('-n', '--network', help='Define a specific network to run docker',
+                              default=None)
 
     # # list builds
     # parser_list = subparsers.add_parser('list')

--- a/pesto-cli/pesto/cli/app.py
+++ b/pesto-cli/pesto/cli/app.py
@@ -65,7 +65,7 @@ def main() -> None:
     elif args.subcommand == 'build':
         build.build(search_build_config(args), args.profile, args.proxy, args.network)
     elif args.subcommand == 'test':
-        test.test(search_build_config(args), args.profile, nvidia=args.nvidia)
+        test.test(search_build_config(args), args.profile, nvidia=args.nvidia, network=args.network)
     elif args.subcommand == 'list':
         list_builds.list_builds(PESTO_WORKSPACE)
 

--- a/pesto-cli/pesto/cli/app.py
+++ b/pesto-cli/pesto/cli/app.py
@@ -48,6 +48,8 @@ def parse_args() -> argparse.Namespace:
     parser_test.add_argument('-p', '--profile', nargs='+', help='Select specific files to update',
                              default=None)
     parser_test.add_argument('--nvidia',  action='store_true', default=False, help='Run docker with nvidia-runtime')
+    parser_test.add_argument('-n', '--network', help='Define a specific network for docker construction',
+                              default="host")
 
     # # list builds
     # parser_list = subparsers.add_parser('list')

--- a/pesto-cli/pesto/cli/app.py
+++ b/pesto-cli/pesto/cli/app.py
@@ -39,6 +39,8 @@ def parse_args() -> argparse.Namespace:
                               default=None)
     parser_build.add_argument('--proxy', help='Define a proxy url to use during docker construction',
                               default=None)
+    parser_build.add_argument('-n', '--network', help='Define a specific network for docker construction',
+                              default="host")
 
     # test
     parser_test = subparsers.add_parser('test')
@@ -59,7 +61,7 @@ def main() -> None:
     if args.subcommand == 'init':
         init.init(args.target, args.template)
     elif args.subcommand == 'build':
-        build.build(search_build_config(args), args.profile, args.proxy)
+        build.build(search_build_config(args), args.profile, args.proxy, args.network)
     elif args.subcommand == 'test':
         test.test(search_build_config(args), args.profile, nvidia=args.nvidia)
     elif args.subcommand == 'list':

--- a/pesto-cli/pesto/cli/build.py
+++ b/pesto-cli/pesto/cli/build.py
@@ -116,8 +116,8 @@ class Builder:
         return self.build_config.workspace
 
 
-def build(build_config_path: str, profiles: List[str], proxy: str = None) -> None:
-    config = BuildConfig.from_path(path=build_config_path, profiles=profiles, proxy=proxy)
+def build(build_config_path: str, profiles: List[str], proxy: str = None, network: str = "host") -> None:
+    config = BuildConfig.from_path(path=build_config_path, profiles=profiles, proxy=proxy, network=network)
 
     builder = Builder(config)
     builder.conf_validation()

--- a/pesto-cli/pesto/cli/core/build_config.py
+++ b/pesto-cli/pesto/cli/core/build_config.py
@@ -14,7 +14,8 @@ class BuildConfig:
     def from_path(path: str,
                   profiles: List[str] = None,
                   proxy: str = None,
-                  pip_extra_index: str = None
+                  pip_extra_index: str = None,
+                  network: str = "host"
                   ):
         assert path is not None
 
@@ -28,7 +29,8 @@ class BuildConfig:
             workspace=build_config.get('workspace'),
             algorithm_path=build_config.get('algorithm_path') or str(Path(path).parent.parent.parent),
             proxy=proxy,
-            pip_extra_index=pip_extra_index)
+            pip_extra_index=pip_extra_index,
+            network=network)
 
     def __init__(self,
                  name: str = None,
@@ -37,13 +39,15 @@ class BuildConfig:
                  workspace: str = None,
                  algorithm_path: str = None,
                  proxy: str = None,
-                 pip_extra_index: str = None):
+                 pip_extra_index: str = None,
+                 network: str = None):
         self.name = name
         self.version = version
         self.algorithm_path = algorithm_path
 
         self.profiles = profiles or []
         self.proxy = proxy or ''
+        self.network = network
         self.pip_extra_index = pip_extra_index or os.environ.get('PIP_EXTRA_INDEX_URL')
         self.workspace = workspace or os.path.join(PESTO_WORKSPACE, self.name, self.full_version)
 

--- a/pesto-cli/pesto/cli/core/build_config.py
+++ b/pesto-cli/pesto/cli/core/build_config.py
@@ -15,7 +15,7 @@ class BuildConfig:
                   profiles: List[str] = None,
                   proxy: str = None,
                   pip_extra_index: str = None,
-                  network: str = "host"
+                  network: str = None
                   ):
         assert path is not None
 

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -39,7 +39,7 @@ class DockerBuilder(object):
 
         docker_image_name = self.build_config.docker_image_name
         cmd = "docker build --no-cache"
-        if network is not None:
+        if self.build_config.network is not None:
             cmd = "{} --network='{}'".format(cmd, self.build_config.network)
         cmd = "{} -t {} {}".format(cmd, docker_image_name, self.build_config.workspace)
         subprocess.call(shlex.split(cmd))

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -38,7 +38,10 @@ class DockerBuilder(object):
             file.write(dockerfile)
 
         docker_image_name = self.build_config.docker_image_name
-        cmd = "docker build --no-cache --network='{}' -t {} {}".format(self.build_config.network, docker_image_name, self.build_config.workspace)
+        cmd = "docker build --no-cache"
+        if network is not None:
+            cmd = "{} --network='{}'".format(cmd, self.build_config.network)
+        cmd = "{} -t {} {}".format(cmd, docker_image_name, self.build_config.workspace)
         subprocess.call(shlex.split(cmd))
 
     def dockerfile(self):

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -38,7 +38,7 @@ class DockerBuilder(object):
             file.write(dockerfile)
 
         docker_image_name = self.build_config.docker_image_name
-        cmd = "docker build --no-cache --network='host' -t {} {}".format(docker_image_name, self.build_config.workspace)
+        cmd = "docker build --no-cache --network='{}' -t {} {}".format(self.build_config.network, docker_image_name, self.build_config.workspace)
         subprocess.call(shlex.split(cmd))
 
     def dockerfile(self):

--- a/pesto-cli/pesto/cli/test.py
+++ b/pesto-cli/pesto/cli/test.py
@@ -5,10 +5,10 @@ from pesto.cli.core.utils import PESTO_LOG
 from pesto.common.testing.test_runner import TestRunner
 
 
-def test(build_config_path, profiles, nvidia=False):
-    build_config = BuildConfig.from_path(path=build_config_path, profiles=profiles)
+def test(build_config_path, profiles, nvidia=False, network="host"):
+    build_config = BuildConfig.from_path(path=build_config_path, profiles=profiles, network=network)
     PESTO_LOG.info('build configuration : {}'.format(build_config))
 
     pesto_path = Path(build_config.algorithm_path) / 'pesto' / 'tests' / 'resources'
 
-    TestRunner(docker_image_name=build_config.docker_image_name, nvidia=nvidia).run_all(pesto_path)
+    TestRunner(docker_image_name=build_config.docker_image_name, network=network, nvidia=nvidia).run_all(pesto_path)

--- a/pesto-cli/pesto/cli/test.py
+++ b/pesto-cli/pesto/cli/test.py
@@ -5,7 +5,7 @@ from pesto.cli.core.utils import PESTO_LOG
 from pesto.common.testing.test_runner import TestRunner
 
 
-def test(build_config_path, profiles, nvidia=False, network="host"):
+def test(build_config_path, profiles, nvidia=False, network=None):
     build_config = BuildConfig.from_path(path=build_config_path, profiles=profiles, network=network)
     PESTO_LOG.info('build configuration : {}'.format(build_config))
 

--- a/pesto-cli/pesto/common/testing/service_manager.py
+++ b/pesto-cli/pesto/common/testing/service_manager.py
@@ -88,10 +88,10 @@ class ServiceManager:
             self.pull()
             logger.info("Starting container with {} on port {}".format(self.docker_image, self.host_port))
 
-            if self.network is None :
+            if self.network is "host":
                 self._container = self.CLIENT.containers.run(
                     self.docker_image,
-                    ports={self.service_port: self.host_port},
+                    network=self.network,
                     detach=True,
                     remove=True,
                     runtime="nvidia" if self.nvidia else None,
@@ -104,6 +104,7 @@ class ServiceManager:
                 self._container = self.CLIENT.containers.run(
                     self.docker_image,
                     network=self.network,
+                    ports={self.service_port: self.host_port},
                     detach=True,
                     remove=True,
                     runtime="nvidia" if self.nvidia else None,

--- a/pesto-cli/pesto/common/testing/service_manager.py
+++ b/pesto-cli/pesto/common/testing/service_manager.py
@@ -29,7 +29,10 @@ class ServiceManager:
         self.image_volume_path = image_volume_path
         self.nvidia = nvidia
         self.attach_when_running = attach_when_running
-        self.network = network
+        if network is None:
+            self.network = "bridge"
+        else:
+            self.network = network
 
         self._container, self._existing_container = self._check_existing_container()
 

--- a/pesto-cli/pesto/common/testing/service_manager.py
+++ b/pesto-cli/pesto/common/testing/service_manager.py
@@ -20,6 +20,7 @@ class ServiceManager:
         image_volume_path: str = "/tmp",
         nvidia=False,
         attach_when_running=False,
+        network: str = None
     ):
         self.docker_image = docker_image
         self.host_port = host_port
@@ -28,6 +29,7 @@ class ServiceManager:
         self.image_volume_path = image_volume_path
         self.nvidia = nvidia
         self.attach_when_running = attach_when_running
+        self.network = network
 
         self._container, self._existing_container = self._check_existing_container()
 
@@ -86,17 +88,30 @@ class ServiceManager:
             self.pull()
             logger.info("Starting container with {} on port {}".format(self.docker_image, self.host_port))
 
-            self._container = self.CLIENT.containers.run(
-                self.docker_image,
-                ports={self.service_port: self.host_port},
-                detach=True,
-                remove=True,
-                runtime="nvidia" if self.nvidia else None,
-                volumes={self.image_volume_path: {
-                    "bind": self.host_volume_path,
-                    "mode": "rw",
-                }},
-            )
+            if self.network is None :
+                self._container = self.CLIENT.containers.run(
+                    self.docker_image,
+                    ports={self.service_port: self.host_port},
+                    detach=True,
+                    remove=True,
+                    runtime="nvidia" if self.nvidia else None,
+                    volumes={self.image_volume_path: {
+                        "bind": self.host_volume_path,
+                        "mode": "rw",
+                    }},
+                )
+            else:
+                self._container = self.CLIENT.containers.run(
+                    self.docker_image,
+                    network=self.network,
+                    detach=True,
+                    remove=True,
+                    runtime="nvidia" if self.nvidia else None,
+                    volumes={self.image_volume_path: {
+                        "bind": self.host_volume_path,
+                        "mode": "rw",
+                    }},
+                )
             time.sleep(2)
             logger.info("Container {} started, available at {}".format(self._container.id, self.server_url))
 

--- a/pesto-cli/pesto/common/testing/test_runner.py
+++ b/pesto-cli/pesto/common/testing/test_runner.py
@@ -12,7 +12,7 @@ TMP_PATH = Path("/tmp/pesto/")
 
 
 class TestRunner:
-    def __init__(self, docker_image_name: str, network: str = "host", nvidia=False):
+    def __init__(self, docker_image_name: str, network: str = None, nvidia=False):
         self.docker_image_name = docker_image_name
         self.nvidia = nvidia
         self.network = network

--- a/pesto-cli/pesto/common/testing/test_runner.py
+++ b/pesto-cli/pesto/common/testing/test_runner.py
@@ -12,9 +12,10 @@ TMP_PATH = Path("/tmp/pesto/")
 
 
 class TestRunner:
-    def __init__(self, docker_image_name: str, nvidia=False):
+    def __init__(self, docker_image_name: str, network: str = "host", nvidia=False):
         self.docker_image_name = docker_image_name
         self.nvidia = nvidia
+        self.network = network
 
         image, tag = self.docker_image_name.split(":")
 

--- a/pesto-cli/tests/cli/test_build_config.py
+++ b/pesto-cli/tests/cli/test_build_config.py
@@ -15,3 +15,12 @@ def test_docker_image_name():
     # then
     expected = '{}:{}-{}'.format(config.name, config.version, '-'.join(config.profiles))
     assert actual == expected
+
+
+def test_network():
+    config = BuildConfig(
+        name='my-service',
+        version='1.2.3',
+        profiles=['p1', 'p2'],
+        network='test_network')
+    assert config.network == "test_network"

--- a/pesto-cli/tests/cli/test_build_config.py
+++ b/pesto-cli/tests/cli/test_build_config.py
@@ -24,3 +24,4 @@ def test_network():
         profiles=['p1', 'p2'],
         network='test_network')
     assert config.network == "test_network"
+    


### PR DESCRIPTION
Feature to be able to set the network during `pesto build` and `pesto test` steps.

The network is passed as a command line option:

```
--network <network_name>
```

The default behaviour is unchanged:

* pesto build uses network `host`
* pesto test uses default network (`bridge`)
