### PR TITLE
Codip 623 overload pythonpath

### DIFF
--- a/pesto-cli/pesto/cli/app.py
+++ b/pesto-cli/pesto/cli/app.py
@@ -39,6 +39,8 @@ def parse_args() -> argparse.Namespace:
                               default=None)
     parser_build.add_argument('--proxy', help='Define a proxy url to use during docker construction',
                               default=None)
+    parser_build.add_argument('-n', '--network', help='Define a specific network for docker construction',
+                              default="host")
 
     # test
     parser_test = subparsers.add_parser('test')
@@ -46,6 +48,8 @@ def parse_args() -> argparse.Namespace:
     parser_test.add_argument('-p', '--profile', nargs='+', help='Select specific files to update',
                              default=None)
     parser_test.add_argument('--nvidia',  action='store_true', default=False, help='Run docker with nvidia-runtime')
+    parser_test.add_argument('-n', '--network', help='Define a specific network to run docker',
+                              default=None)
 
     # # list builds
     # parser_list = subparsers.add_parser('list')
@@ -59,9 +63,9 @@ def main() -> None:
     if args.subcommand == 'init':
         init.init(args.target, args.template)
     elif args.subcommand == 'build':
-        build.build(search_build_config(args), args.profile, args.proxy)
+        build.build(search_build_config(args), args.profile, args.proxy, args.network)
     elif args.subcommand == 'test':
-        test.test(search_build_config(args), args.profile, nvidia=args.nvidia)
+        test.test(search_build_config(args), args.profile, nvidia=args.nvidia, network=args.network)
     elif args.subcommand == 'list':
         list_builds.list_builds(PESTO_WORKSPACE)
 

--- a/pesto-cli/pesto/cli/build.py
+++ b/pesto-cli/pesto/cli/build.py
@@ -116,8 +116,8 @@ class Builder:
         return self.build_config.workspace
 
 
-def build(build_config_path: str, profiles: List[str], proxy: str = None) -> None:
-    config = BuildConfig.from_path(path=build_config_path, profiles=profiles, proxy=proxy)
+def build(build_config_path: str, profiles: List[str], proxy: str = None, network: str = "host") -> None:
+    config = BuildConfig.from_path(path=build_config_path, profiles=profiles, proxy=proxy, network=network)
 
     builder = Builder(config)
     builder.conf_validation()

--- a/pesto-cli/pesto/cli/core/build_config.py
+++ b/pesto-cli/pesto/cli/core/build_config.py
@@ -14,7 +14,8 @@ class BuildConfig:
     def from_path(path: str,
                   profiles: List[str] = None,
                   proxy: str = None,
-                  pip_extra_index: str = None
+                  pip_extra_index: str = None,
+                  network: str = None
                   ):
         assert path is not None
 
@@ -28,7 +29,8 @@ class BuildConfig:
             workspace=build_config.get('workspace'),
             algorithm_path=build_config.get('algorithm_path') or str(Path(path).parent.parent.parent),
             proxy=proxy,
-            pip_extra_index=pip_extra_index)
+            pip_extra_index=pip_extra_index,
+            network=network)
 
     def __init__(self,
                  name: str = None,
@@ -37,13 +39,15 @@ class BuildConfig:
                  workspace: str = None,
                  algorithm_path: str = None,
                  proxy: str = None,
-                 pip_extra_index: str = None):
+                 pip_extra_index: str = None,
+                 network: str = None):
         self.name = name
         self.version = version
         self.algorithm_path = algorithm_path
 
         self.profiles = profiles or []
         self.proxy = proxy or ''
+        self.network = network
         self.pip_extra_index = pip_extra_index or os.environ.get('PIP_EXTRA_INDEX_URL')
         self.workspace = workspace or os.path.join(PESTO_WORKSPACE, self.name, self.full_version)
 

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -60,7 +60,7 @@ class DockerBuilder(object):
         return {
             'PESTO_PROFILE': self.build_config.full_version,
             **self.environments,
-            'PYTHONPATH': ":".join(["$PYTHONPATH${PYTHONPATH:+:}", self._python_path])
+            'PYTHONPATH': "".join(["$PYTHONPATH${PYTHONPATH:+:}", self._python_path])
         }
 
     @property

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -52,7 +52,6 @@ class DockerBuilder(object):
             pip_extra_index=self.build_config.pip_extra_index,
             pip_proxies=self.build_config.pip_proxies,
             env_variables=self._env_variables(),
-            python_env_variables=self._python_env_variables(),
             pip_requirements=self._pip_requirements(),
             resources_requirements=self._resources()
         )
@@ -60,15 +59,8 @@ class DockerBuilder(object):
     def _env_variables(self):
         return {
             'PESTO_PROFILE': self.build_config.full_version,
-            **self.environments
-        }
-
-    def _python_env_variables(self):
-        return {
-            ":".join(["${PYTHONPATH", "+$PYTHONPATH",
-                                    "".join([self._python_path, "}"])]),
-            ":".join(["${PYTHONPATH",
-                                    "".join(["-", self._python_path, "}"])])
+            **self.environments,
+            'PYTHONPATH': ":".join(["$PYTHONPATH", self._python_path])
         }
 
     @property

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -60,7 +60,7 @@ class DockerBuilder(object):
         return {
             'PESTO_PROFILE': self.build_config.full_version,
             **self.environments,
-            'PYTHONPATH': self._python_path
+            'PYTHONPATH': ":".join(["$PYTHONPATH", self._python_path])
         }
 
     @property

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -52,6 +52,7 @@ class DockerBuilder(object):
             pip_extra_index=self.build_config.pip_extra_index,
             pip_proxies=self.build_config.pip_proxies,
             env_variables=self._env_variables(),
+            python_env_variables=self._python_env_variables(),
             pip_requirements=self._pip_requirements(),
             resources_requirements=self._resources()
         )
@@ -59,8 +60,15 @@ class DockerBuilder(object):
     def _env_variables(self):
         return {
             'PESTO_PROFILE': self.build_config.full_version,
-            **self.environments,
-            'PYTHONPATH': ":".join(["$PYTHONPATH", self._python_path])
+            **self.environments
+        }
+
+    def _python_env_variables(self):
+        return {
+            ":".join(["${PYTHONPATH", "+$PYTHONPATH",
+                                    "".join([self._python_path, "}"])]),
+            ":".join(["${PYTHONPATH",
+                                    "".join(["-", self._python_path, "}"])])
         }
 
     @property

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -38,7 +38,10 @@ class DockerBuilder(object):
             file.write(dockerfile)
 
         docker_image_name = self.build_config.docker_image_name
-        cmd = "docker build --no-cache --network='host' -t {} {}".format(docker_image_name, self.build_config.workspace)
+        cmd = "docker build --no-cache"
+        if self.build_config.network is not None:
+            cmd = "{} --network='{}'".format(cmd, self.build_config.network)
+        cmd = "{} -t {} {}".format(cmd, docker_image_name, self.build_config.workspace)
         subprocess.call(shlex.split(cmd))
 
     def dockerfile(self):

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -60,7 +60,7 @@ class DockerBuilder(object):
         return {
             'PESTO_PROFILE': self.build_config.full_version,
             **self.environments,
-            'PYTHONPATH': ":".join(["$PYTHONPATH", self._python_path])
+            'PYTHONPATH': ":".join(["$PYTHONPATH${PYTHONPATH:+:}", self._python_path])
         }
 
     @property

--- a/pesto-cli/pesto/cli/resources/Dockerfile
+++ b/pesto-cli/pesto/cli/resources/Dockerfile
@@ -20,6 +20,9 @@ RUN echo '***** define ENV variables ******************************'
 {% for key, value in env_variables.items() -%}
     ENV ${key}=${value}
 {% endfor %}
+{% for value in python_env_variables -%}
+    ENV PYTHONPATH=${value}
+{% endfor %}
 
 RUN echo '***** configuration files ******************************'
     COPY pesto/api_geo_process_v1.0.yaml /etc/pesto/

--- a/pesto-cli/pesto/cli/resources/Dockerfile
+++ b/pesto-cli/pesto/cli/resources/Dockerfile
@@ -20,9 +20,6 @@ RUN echo '***** define ENV variables ******************************'
 {% for key, value in env_variables.items() -%}
     ENV ${key}=${value}
 {% endfor %}
-{% for value in python_env_variables -%}
-    ENV PYTHONPATH=${value}
-{% endfor %}
 
 RUN echo '***** configuration files ******************************'
     COPY pesto/api_geo_process_v1.0.yaml /etc/pesto/

--- a/pesto-cli/pesto/cli/test.py
+++ b/pesto-cli/pesto/cli/test.py
@@ -5,10 +5,10 @@ from pesto.cli.core.utils import PESTO_LOG
 from pesto.common.testing.test_runner import TestRunner
 
 
-def test(build_config_path, profiles, nvidia=False):
-    build_config = BuildConfig.from_path(path=build_config_path, profiles=profiles)
+def test(build_config_path, profiles, nvidia=False, network=None):
+    build_config = BuildConfig.from_path(path=build_config_path, profiles=profiles, network=network)
     PESTO_LOG.info('build configuration : {}'.format(build_config))
 
     pesto_path = Path(build_config.algorithm_path) / 'pesto' / 'tests' / 'resources'
 
-    TestRunner(docker_image_name=build_config.docker_image_name, nvidia=nvidia).run_all(pesto_path)
+    TestRunner(docker_image_name=build_config.docker_image_name, network=network, nvidia=nvidia).run_all(pesto_path)

--- a/pesto-cli/pesto/common/testing/test_runner.py
+++ b/pesto-cli/pesto/common/testing/test_runner.py
@@ -12,9 +12,10 @@ TMP_PATH = Path("/tmp/pesto/")
 
 
 class TestRunner:
-    def __init__(self, docker_image_name: str, nvidia=False):
+    def __init__(self, docker_image_name: str, network: str = None, nvidia=False):
         self.docker_image_name = docker_image_name
         self.nvidia = nvidia
+        self.network = network
 
         image, tag = self.docker_image_name.split(":")
 

--- a/pesto-cli/tests/cli/test_build_config.py
+++ b/pesto-cli/tests/cli/test_build_config.py
@@ -38,17 +38,8 @@ def test_pythonpath():
     dockerbuilder = DockerBuilder(requirements, build_config).dockerfile()
 
     # when
-    dockerfile_lines = dockerbuilder.split("\n")
-    pythonpath_lines = []
-    for line in dockerfile_lines:
-       if line[:14] == "ENV PYTHONPATH":
-           pythonpath_lines.append(line)
+    actual =  dockerbuilder.split("\n")[17]
 
     # then
-    expected = 'ENV PYTHONPATH=${PYTHONPATH:-/opt/my-service}'
-    assert pythonpath_lines[0] == expected
-
-    expected = 'ENV PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:/opt/my-service}'
-    assert pythonpath_lines[1] == expected
-
-
+    expected = 'ENV PYTHONPATH=$PYTHONPATH:/opt/my-service'
+    assert actual == expected

--- a/pesto-cli/tests/cli/test_build_config.py
+++ b/pesto-cli/tests/cli/test_build_config.py
@@ -39,6 +39,10 @@ def test_pythonpath():
 
     # when
     actual = dockerbuilder.split("\n")[17]
+    dockerfile_lines = dockerbuilder.split("\n")
+    for line in dockerfile_lines:
+        if line[:14] == "ENV PYTHONPATH":
+            actual = line
 
     # then
     expected = 'ENV PYTHONPATH=$PYTHONPATH${PYTHONPATH:+:}/opt/my-service'

--- a/pesto-cli/tests/cli/test_build_config.py
+++ b/pesto-cli/tests/cli/test_build_config.py
@@ -24,7 +24,7 @@ def test_network():
         profiles=['p1', 'p2'],
         network='test_network')
     assert config.network == "test_network"
-    
+
 
 def test_pythonpath():
     # given
@@ -38,7 +38,7 @@ def test_pythonpath():
     dockerbuilder = DockerBuilder(requirements, build_config).dockerfile()
 
     # when
-    actual =  dockerbuilder.split("\n")[17]
+    actual = dockerbuilder.split("\n")[17]
 
     # then
     expected = 'ENV PYTHONPATH=$PYTHONPATH${PYTHONPATH:+:}/opt/my-service'

--- a/pesto-cli/tests/cli/test_build_config.py
+++ b/pesto-cli/tests/cli/test_build_config.py
@@ -41,5 +41,5 @@ def test_pythonpath():
     actual =  dockerbuilder.split("\n")[17]
 
     # then
-    expected = 'ENV PYTHONPATH=$PYTHONPATH:/opt/my-service'
+    expected = 'ENV PYTHONPATH=$PYTHONPATH${PYTHONPATH:+:}:/opt/my-service'
     assert actual == expected

--- a/pesto-cli/tests/cli/test_build_config.py
+++ b/pesto-cli/tests/cli/test_build_config.py
@@ -1,5 +1,5 @@
 from pesto.cli.core.build_config import BuildConfig
-
+from pesto.cli.core.docker_builder import DockerBuilder
 
 def test_docker_image_name():
     # given
@@ -25,3 +25,21 @@ def test_network():
         network='test_network')
     assert config.network == "test_network"
     
+
+def test_pythonpath():
+    # given
+    build_config = BuildConfig(
+        name='my-service',
+        version='1.2.3',
+        profiles=['p1', 'p2'],
+        workspace=".")
+    requirements={"dockerBaseImage":{}, "requirements":{}, "environments":{}}
+
+    dockerbuilder = DockerBuilder(requirements, build_config).dockerfile()
+
+    # when
+    actual =  dockerbuilder.split("\n")[17]
+
+    # then
+    expected = 'ENV PYTHONPATH=$PYTHONPATH:/opt/my-service'
+    assert actual == expected

--- a/pesto-cli/tests/cli/test_build_config.py
+++ b/pesto-cli/tests/cli/test_build_config.py
@@ -38,8 +38,17 @@ def test_pythonpath():
     dockerbuilder = DockerBuilder(requirements, build_config).dockerfile()
 
     # when
-    actual =  dockerbuilder.split("\n")[17]
+    dockerfile_lines = dockerbuilder.split("\n")
+    pythonpath_lines = []
+    for line in dockerfile_lines:
+       if line[:14] == "ENV PYTHONPATH":
+           pythonpath_lines.append(line)
 
     # then
-    expected = 'ENV PYTHONPATH=$PYTHONPATH:/opt/my-service'
-    assert actual == expected
+    expected = 'ENV PYTHONPATH=${PYTHONPATH:-/opt/my-service}'
+    assert pythonpath_lines[0] == expected
+
+    expected = 'ENV PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:/opt/my-service}'
+    assert pythonpath_lines[1] == expected
+
+

--- a/pesto-cli/tests/cli/test_build_config.py
+++ b/pesto-cli/tests/cli/test_build_config.py
@@ -15,3 +15,13 @@ def test_docker_image_name():
     # then
     expected = '{}:{}-{}'.format(config.name, config.version, '-'.join(config.profiles))
     assert actual == expected
+
+
+def test_network():
+    config = BuildConfig(
+        name='my-service',
+        version='1.2.3',
+        profiles=['p1', 'p2'],
+        network='test_network')
+    assert config.network == "test_network"
+    

--- a/pesto-cli/tests/cli/test_build_config.py
+++ b/pesto-cli/tests/cli/test_build_config.py
@@ -41,5 +41,5 @@ def test_pythonpath():
     actual =  dockerbuilder.split("\n")[17]
 
     # then
-    expected = 'ENV PYTHONPATH=$PYTHONPATH${PYTHONPATH:+:}:/opt/my-service'
+    expected = 'ENV PYTHONPATH=$PYTHONPATH${PYTHONPATH:+:}/opt/my-service'
     assert actual == expected


### PR DESCRIPTION
Feature to append PYTHONPATH during `pesto build` instead of overwriting. 

It helps packaging algorithms that are not entirely packaged by pip, and need ad-hoc `PYTHONPATH`.

In the dockerfile, you now get:

```
ENV PYTHONPATH=$PYTHONPATH${PYTHONPATH:+:}/opt/my-pesto-service
```