### PR TITLE
Secrets handling

### DIFF
--- a/pesto-cli/pesto/cli/core/build_config.py
+++ b/pesto-cli/pesto/cli/core/build_config.py
@@ -14,7 +14,7 @@ class BuildConfig:
     def from_path(path: str,
                   profiles: List[str] = None,
                   proxy: str = None,
-                  pip_index: str = None,
+                  pip_config_file: str = None,
                   pip_extra_index: str = None,
                   use_buildkit: bool = False,
                   network: str = None
@@ -31,7 +31,7 @@ class BuildConfig:
             workspace=build_config.get('workspace'),
             algorithm_path=build_config.get('algorithm_path') or str(Path(path).parent.parent.parent),
             proxy=proxy,
-            pip_index=pip_index,
+            pip_config_file=pip_config_file,
             pip_extra_index=pip_extra_index,
             use_buildkit=use_buildkit,
             network=network)
@@ -43,7 +43,7 @@ class BuildConfig:
                  workspace: str = None,
                  algorithm_path: str = None,
                  proxy: str = None,
-                 pip_index: str = None,
+                 pip_config_file: str = None,
                  pip_extra_index: str = None,
                  use_buildkit: bool = False,
                  network: str = None):
@@ -54,7 +54,7 @@ class BuildConfig:
         self.profiles = profiles or []
         self.proxy = proxy or ''
         self.network = network
-        self.pip_index = pip_index or os.environ.get('PIP_INDEX_URL')
+        self.pip_config_file = pip_config_file or os.environ.get('PIP_CONFIG_FILE')
         self.pip_extra_index = pip_extra_index or os.environ.get('PIP_EXTRA_INDEX_URL')
         self.use_buildkit = use_buildkit or (os.environ.get('DOCKER_BUILDKIT') == '1')
         self.workspace = workspace or os.path.join(PESTO_WORKSPACE, self.name, self.full_version)

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -66,6 +66,7 @@ class DockerBuilder(object):
                 os.remove(extra_index_url_full_path)
         # add tag name and context path
         cmd = "{} -t {} {}".format(cmd, docker_image_name, self.build_config.workspace)
+
         subprocess.call(shlex.split(cmd))
 
     def dockerfile(self):

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -29,18 +29,43 @@ class DockerBuilder(object):
         self.base_image = requirements['dockerBaseImage']
         self.requirements = requirements['requirements']
         self.environments = requirements['environments']
+        self._index_url_secret_path = 'pip_index_url.txt'
+        self._extra_index_url_secret_path = 'pip_extra_index_url.txt'
 
     def build(self, path: str) -> None:
         dockerfile = self.dockerfile()
 
-        path = os.path.join(path, 'Dockerfile')
-        with open(path, 'w+') as file:
+        dockerfile_path = os.path.join(path, 'Dockerfile')
+        with open(dockerfile_path, 'w+') as file:
             file.write(dockerfile)
 
         docker_image_name = self.build_config.docker_image_name
         cmd = "docker build --no-cache"
         if self.build_config.network is not None:
             cmd = "{} --network='{}'".format(cmd, self.build_config.network)
+        # add secret mount options if use_buildkit=True
+        index_url_full_path = os.path.join(path, self._index_url_secret_path)
+        extra_index_url_full_path = os.path.join(path, self._extra_index_url_secret_path)
+        if self.build_config.use_buildkit:
+            if self.build_config.pip_index:
+                # write secret into file
+                with open(index_url_full_path, 'w') as fd:
+                    fd.write(self.build_config.pip_index)
+                # add mount option
+                cmd += " --secret id=index_url,src="+self._index_url_secret_path
+            if self.build_config.pip_extra_index:
+                # write secret into file
+                with open(extra_index_url_full_path, 'w') as fd:
+                    fd.write(self.build_config.pip_extra_index)
+                # add mount option
+                cmd += " --secret id=extra_index_url,src="+self._extra_index_url_secret_path
+        else:
+            # clean any secret file in the build context
+            if os.path.exists(index_url_full_path):
+                os.remove(index_url_full_path)
+            if os.path.exists(extra_index_url_full_path):
+                os.remove(extra_index_url_full_path)
+        # add tag name and context path
         cmd = "{} -t {} {}".format(cmd, docker_image_name, self.build_config.workspace)
         subprocess.call(shlex.split(cmd))
 
@@ -49,8 +74,9 @@ class DockerBuilder(object):
         return template.render(
             base_image=self.base_image,
             algo_name=self.algo_name,
+            pip_index=self.build_config.pip_index,
             pip_extra_index=self.build_config.pip_extra_index,
-            pip_proxies=self.build_config.pip_proxies,
+            use_buildkit=self.build_config.use_buildkit,
             env_variables=self._env_variables(),
             pip_requirements=self._pip_requirements(),
             resources_requirements=self._resources()

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -41,7 +41,7 @@ class DockerBuilder(object):
 
         docker_image_name = self.build_config.docker_image_name
         cmd = "docker build --no-cache"
-        if self.build_config.network is not None:
+        if self.build_config.network:
             cmd = "{} --network='{}'".format(cmd, self.build_config.network)
         # add secret mount options if use_buildkit=True
         pip_config_full_path = os.path.join(path, 'pip.conf')

--- a/pesto-cli/pesto/cli/core/docker_builder.py
+++ b/pesto-cli/pesto/cli/core/docker_builder.py
@@ -49,15 +49,15 @@ class DockerBuilder(object):
         if self.build_config.use_buildkit:
             if self.build_config.pip_config_file:
                 # copy pip config file into workspace
-                shutil.copy(self.build_config.pip_config_file, pip_config_full_path)
+                shutil.copyfile(self.build_config.pip_config_file, pip_config_full_path)
                 # add mount option
-                cmd += " --secret id=pip_config,src=pip.conf"
+                cmd += " --secret id=pip_config,src="+pip_config_full_path
             if self.build_config.pip_extra_index:
                 # write secret into file
                 with open(extra_index_url_full_path, 'w') as fd:
                     fd.write(self.build_config.pip_extra_index)
                 # add mount option
-                cmd += " --secret id=extra_index_url,src="+self._extra_index_url_secret_path
+                cmd += " --secret id=extra_index_url,src="+extra_index_url_full_path
         else:
             # clean any secret file in the build context
             if os.path.exists(pip_config_full_path):

--- a/pesto-cli/pesto/cli/resources/Dockerfile
+++ b/pesto-cli/pesto/cli/resources/Dockerfile
@@ -14,7 +14,7 @@ COPY pip.conf /etc
 {% if use_buildkit != True %}
 ARG PIP_EXTRA_INDEX_URL=${pip_extra_index}
 {%  else %}
-  {%  set secret_mount = secret_mount ~ ' --mount=type=secret,id=extra_index_url PIP_EXTRA_INDEX_URL=`cat /run/secrets/extra_index_url`;' %}
+  {%  set secret_mount = secret_mount ~ ' --mount=type=secret,id=extra_index_url export PIP_EXTRA_INDEX_URL=`cat /run/secrets/extra_index_url` &&' %}
 {%  endif %}
 {%  endif %}
 

--- a/pesto-cli/pesto/cli/resources/Dockerfile
+++ b/pesto-cli/pesto/cli/resources/Dockerfile
@@ -2,17 +2,29 @@ FROM ${base_image}
 CMD  [ "processing" ]
 ENTRYPOINT []
 
+{% if pip_index != None %}
+{% if use_buildkit != True %}
+ARG PIP_INDEX_URL=${pip_index}
+{%  else %}
+  {%  set secret_mount = secret_mount ~ ' --mount=type=secret,id=index_url PIP_INDEX_URL=`cat /run/secrets/index_url`' %}
+{%  endif %}
+{%  endif %}
+
 {% if pip_extra_index != None %}
-ENV PIP_EXTRA_INDEX_URL=${pip_extra_index}
+{% if use_buildkit != True %}
+ARG PIP_EXTRA_INDEX_URL=${pip_extra_index}
+{%  else %}
+  {%  set secret_mount = secret_mount ~ ' --mount=type=secret,id=extra_index_url PIP_EXTRA_INDEX_URL=`cat /run/secrets/extra_index_url`' %}
+{%  endif %}
 {%  endif %}
 
 RUN python3 -V
 RUN ln -s `which pip` /usr/bin/pip; echo "pip is ready"
-RUN pip install --upgrade pip
+RUN ${secret_mount} pip install --upgrade pip
 RUN pip -V
 
 RUN echo '***** fix certificates for rasterio ******************************'
-    RUN pip install certifi>=2017.4.17
+    RUN ${secret_mount} pip install certifi>=2017.4.17
     RUN mkdir -p /etc/pki/tls/certs
     RUN ln -sf /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
 
@@ -30,7 +42,7 @@ RUN echo '***** configuration files ******************************'
 RUN echo '***** install pip requirements ******************************'
     {% for name in pip_requirements -%}
         COPY requirements/${name} /tmp
-        RUN pip install /tmp/${name}
+        RUN ${secret_mount} pip install /tmp/${name}
         RUN rm -rf /tmp/${name}
     {% endfor %}
 
@@ -41,9 +53,9 @@ RUN echo '***** copy algo resources requirements ******************************'
 
 RUN echo '***** install PESTO ******************************'
     COPY dist /opt/tmp/pesto/dist
-    RUN if test -e /opt/tmp/pesto/dist/*.whl; then pip install /opt/tmp/pesto/dist/processing_factory*.whl; fi
-    RUN if test ! -e /opt/tmp/pesto/dist/*.whl; then pip install processing-factory; fi
+    RUN ${secret_mount} if test -e /opt/tmp/pesto/dist/*.whl; then pip install /opt/tmp/pesto/dist/processing_factory*.whl; fi
+    RUN ${secret_mount} if test ! -e /opt/tmp/pesto/dist/*.whl; then pip install processing-factory; fi
 
 RUN echo '***** copy & install algorithm ******************************'
     COPY ${algo_name} /opt/${algo_name}
-    RUN pip install /opt/${algo_name}
+    RUN ${secret_mount} pip install /opt/${algo_name}

--- a/pesto-cli/pesto/cli/resources/Dockerfile
+++ b/pesto-cli/pesto/cli/resources/Dockerfile
@@ -2,11 +2,11 @@ FROM ${base_image}
 CMD  [ "processing" ]
 ENTRYPOINT []
 
-{% if pip_index != None %}
+{% if pip_config_file != None %}
 {% if use_buildkit != True %}
-ARG PIP_INDEX_URL=${pip_index}
+COPY pip.conf /etc
 {%  else %}
-  {%  set secret_mount = secret_mount ~ ' --mount=type=secret,id=index_url PIP_INDEX_URL=`cat /run/secrets/index_url`' %}
+  {%  set secret_mount = secret_mount ~ ' --mount=type=secret,id=pip_config,dst=/etc/pip.conf' %}
 {%  endif %}
 {%  endif %}
 

--- a/pesto-cli/pesto/cli/resources/Dockerfile
+++ b/pesto-cli/pesto/cli/resources/Dockerfile
@@ -14,7 +14,7 @@ COPY pip.conf /etc
 {% if use_buildkit != True %}
 ARG PIP_EXTRA_INDEX_URL=${pip_extra_index}
 {%  else %}
-  {%  set secret_mount = secret_mount ~ ' --mount=type=secret,id=extra_index_url PIP_EXTRA_INDEX_URL=`cat /run/secrets/extra_index_url`' %}
+  {%  set secret_mount = secret_mount ~ ' --mount=type=secret,id=extra_index_url PIP_EXTRA_INDEX_URL=`cat /run/secrets/extra_index_url`;' %}
 {%  endif %}
 {%  endif %}
 

--- a/pesto-cli/tests/cli/test_build_config.py
+++ b/pesto-cli/tests/cli/test_build_config.py
@@ -1,5 +1,9 @@
 from pesto.cli.core.build_config import BuildConfig
 from pesto.cli.core.docker_builder import DockerBuilder
+import os
+
+_sample_pip_index_url="https://MYUSER:MYSECRET@some.artifactory.com/public/repo/simple"
+_sample_pip_extra_index_url="https://MYUSER:MYSECRET@some.artifactory.com/private/repo/simple"
 
 def test_docker_image_name():
     # given
@@ -41,9 +45,92 @@ def test_pythonpath():
     actual = dockerbuilder.split("\n")[17]
     dockerfile_lines = dockerbuilder.split("\n")
     for line in dockerfile_lines:
-        if line[:14] == "ENV PYTHONPATH":
+        if line.startswith("ENV PYTHONPATH"):
             actual = line
 
     # then
     expected = 'ENV PYTHONPATH=$PYTHONPATH${PYTHONPATH:+:}/opt/my-service'
     assert actual == expected
+
+def test_pip_indexes_arg():
+    # given
+    env_backup = dict(os.environ)
+    os.environ["PIP_INDEX_URL"] = _sample_pip_index_url
+    os.environ["PIP_EXTRA_INDEX_URL"] = _sample_pip_extra_index_url
+    if 'DOCKER_BUILDKIT' in os.environ:
+        del os.environ['DOCKER_BUILDKIT']
+    build_config = BuildConfig(
+        name='my-service',
+        version='1.2.3',
+        profiles=['p1', 'p2'],
+        workspace=".")
+    requirements={"dockerBaseImage":{}, "requirements":{}, "environments":{}}
+
+    dockerbuilder = DockerBuilder(requirements, build_config).dockerfile()
+
+    if "PIP_INDEX_URL" in env_backup:
+        os.environ["PIP_INDEX_URL"] = env_backup["PIP_INDEX_URL"]
+    else:
+        del os.environ["PIP_INDEX_URL"]
+    if "PIP_EXTRA_INDEX_URL" in env_backup:
+        os.environ["PIP_EXTRA_INDEX_URL"] = env_backup["PIP_EXTRA_INDEX_URL"]
+    else:
+        del os.environ["PIP_EXTRA_INDEX_URL"]
+
+    # when
+    dockerfile_lines = dockerbuilder.split("\n")
+    actual_index = "LINE_NOT_FOUND"
+    for line in dockerfile_lines:
+        if line.startswith("ARG PIP_INDEX_URL="):
+            actual_index = line
+            break
+
+    actual_extra_index = "LINE_NOT_FOUND"
+    for line in dockerfile_lines:
+        if line.startswith("ARG PIP_EXTRA_INDEX_URL="):
+            actual_extra_index = line
+            break
+
+    # then
+    assert actual_index == 'ARG PIP_INDEX_URL='+_sample_pip_index_url
+    assert actual_extra_index == 'ARG PIP_EXTRA_INDEX_URL='+_sample_pip_extra_index_url
+
+
+def test_pip_indexes_secret():
+    # given
+    env_backup = dict(os.environ)
+    os.environ["PIP_INDEX_URL"] = _sample_pip_index_url
+    os.environ["PIP_EXTRA_INDEX_URL"] = _sample_pip_extra_index_url
+    os.environ['DOCKER_BUILDKIT'] = '1'
+    build_config = BuildConfig(
+        name='my-service',
+        version='1.2.3',
+        profiles=['p1', 'p2'],
+        workspace=".")
+    requirements={"dockerBaseImage":{}, "requirements":{}, "environments":{}}
+
+    dockerbuilder = DockerBuilder(requirements, build_config).dockerfile()
+
+    if "PIP_INDEX_URL" in env_backup:
+        os.environ["PIP_INDEX_URL"] = env_backup["PIP_INDEX_URL"]
+    else:
+        del os.environ["PIP_INDEX_URL"]
+    if "PIP_EXTRA_INDEX_URL" in env_backup:
+        os.environ["PIP_EXTRA_INDEX_URL"] = env_backup["PIP_EXTRA_INDEX_URL"]
+    else:
+        del os.environ["PIP_EXTRA_INDEX_URL"]
+    if not "DOCKER_BUILDKIT" in env_backup:
+        del os.environ['DOCKER_BUILDKIT']
+
+    # when
+    dockerfile_lines = dockerbuilder.split("\n")
+    pip_install_lines = []
+    for line in dockerfile_lines:
+        if " pip install " in line:
+            pip_install_lines.append(line)
+
+    # then
+    assert len(pip_install_lines) > 0
+    for line in pip_install_lines:
+        assert " --mount=type=secret,id=index_url " in line
+        assert " --mount=type=secret,id=extra_index_url " in line


### PR DESCRIPTION
This pull request is proposed to resolve issue #9.

Some element for the context: we use PESTO in combination with a pip registry on a Artifactory instance. And the current implementation of the `PIP_EXTRA_INDEX_URL` is leaking any credentials from this URL in the final image.

The main modifications are:

- A new mode to configure the `pip` command run when building a service. In addition to the environment variable `PIP_EXTRA_INDEX_URL` that was already sent to the service Dockerfile, the variable `PIP_CONFIG_FILE` is now detected and the file pointed is exposed in the service container during `pesto build`. This file can be used to fully configure pip (index-url, extra-index-url, path to certificates, ...).
- Support for the BuildKit mode. This mode introduce a more secure way to pass secrets and credentials during a docker build, without leaking them in the final image. When this mode is enabled ( `DOCKER_BUILDKIT=1` ), the content of PIP_EXTRA_INDEX_URL and PIP_CONFIG_FILE is exposed during docker build using  `--secret` option:
    - the extra-index-url is exported at the beginning of each line with a `pip install`
    - the config file is mounted on `/etc/pip.conf` before each `pip install`
- When BuildKit is not enabled the credentials are passed:
    - with a `ARG` command for the extra-index-url
    - by a `COPY` to `/etc/pip.conf` for the config file

Two tests have been added to verify the generation of the service Dockerfile. However, no test is added to validate a `pesto build` command.

Regarding the `--network` option, a small modification is made. Now, giving `--network ''` to pesto will remove any `--network` option in the actual `docker build` command line. This is helpful to let docker use its default networking mode.

Feel free to comment.