### PR TITLE
Fix logger level for non-root logger calls

### DIFF
--- a/pesto-cli/pesto/ws/app.py
+++ b/pesto-cli/pesto/ws/app.py
@@ -83,6 +83,7 @@ class InterceptHandler(logging.Handler):
 def setup_logging():
     logging.root.handlers = [InterceptHandler()]
     logging.root.setLevel(level=settings.log_level)
+    logging.root.handlers[0].setLevel(level=settings.log_level)
     for name in logging.root.manager.loggerDict.keys():
         logging.getLogger(name).handlers = []
         logging.getLogger(name).propagate = True


### PR DESCRIPTION
After using the `PESTO_LOG_LEVEL` variable from a pesto-based service, we noticed that logs emitted from non-root Python logger were not properly selected.

According to this [reference](https://docs.python.org/3/howto/logging.html#logging-flow), the requested level needs to be set on the root handler too.

To check the behaviour:
* build a sample service
* start the service with `PESTO_LOG_LEVEL=WARNING`
* the very first pesto log 'INFO: Started server process [1]' should be removed.